### PR TITLE
PublicInboxMessage: Removes internal constructor in InboxMessage so it c...

### DIFF
--- a/source/inbox/InboxMessage.cs
+++ b/source/inbox/InboxMessage.cs
@@ -31,8 +31,6 @@ namespace com.esendex.sdk.inbox
         public DateTime? ReceivedAt { get; set; }
         public bool ShouldSerializeReceivedAt() { return ReceivedAt.HasValue; }
 
-        internal InboxMessage() : base() { }
-
         /// <summary>
         /// Determines whether the specified System.Object are considered equal.
         /// </summary>


### PR DESCRIPTION
Removes the internal only constructor of InboxMessage so that it can be created outside the SDK.

This is required in unit tests for mocking the IInboxService to return a fake message.
