### PR TITLE
Added MessageBatchesResource to get messages from batch ID.

### DIFF
--- a/source/com.esendex.sdk.csproj
+++ b/source/com.esendex.sdk.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Request.cs" />
     <Compile Include="rest\resources\ContactsResource.cs" />
     <Compile Include="rest\resources\InboxMessagesResource.cs" />
+    <Compile Include="rest\resources\MessageBatchesResource.cs" />
     <Compile Include="rest\resources\MessageHeadersResource.cs" />
     <Compile Include="core\IPagedCollection.cs" />
     <Compile Include="messaging\Message.cs" />

--- a/source/rest/resources/MessageBatchesResource.cs
+++ b/source/rest/resources/MessageBatchesResource.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace com.esendex.sdk.rest.resources
+{
+    internal class MessageBatchesResource : RestResource
+    {
+        public override string ResourceName
+        {
+            get { return "messagebatches"; }
+        }
+
+        public override string ResourceVersion
+        {
+            get { return "v1.0"; }
+        }
+
+        public MessageBatchesResource(Guid id) 
+        {
+            ResourcePath += string.Format("/{0}/messages", id);
+        }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as MessageBatchesResource;
+
+            if (other == null) return false;
+
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+    }
+}

--- a/source/sent/ISentService.cs
+++ b/source/sent/ISentService.cs
@@ -35,5 +35,13 @@ namespace com.esendex.sdk.sent
         /// <exception cref="System.ArgumentException"></exception>
         /// <exception cref="System.Net.WebException"></exception>
         SentMessageCollection GetMessages(string accountReference, int pageNumber, int pageSize);
+
+        /// <summary>
+        /// Gets a com.esendex.sdk.sent.SentMessageCollection instance containing sent messages from a batch.
+        /// </summary>
+        /// <param name="id">A System.Guid instance that contains the Id of a sent batch.</param>
+        /// <returns>A com.esendex.sdk.sent.SentMessageCollection instance that contains the sent message.</returns>
+        /// <exception cref="System.Net.WebException"></exception>
+        SentMessageCollection GetBatchMessages(Guid id);
     }
 }

--- a/source/sent/SentService.cs
+++ b/source/sent/SentService.cs
@@ -78,5 +78,17 @@ namespace com.esendex.sdk.sent
 
             return MakeRequest<SentMessageCollection>(HttpMethod.GET, resource);
         }
+
+        /// <summary>
+        /// Gets a com.esendex.sdk.sent.SentMessageCollection instance containing sent messages from a batch.
+        /// </summary>
+        /// <param name="id">A System.Guid instance that contains the Id of a sent batch.</param>
+        /// <returns>A com.esendex.sdk.sent.SentMessageCollection instance that contains the sent message.</returns>
+        /// <exception cref="System.Net.WebException"></exception>
+        public SentMessageCollection GetBatchMessages(Guid id)
+        {
+            RestResource resource = new MessageBatchesResource(id);
+            return MakeRequest<SentMessageCollection>(HttpMethod.GET, resource);
+        }
     }
 }

--- a/test/sent/SentServiceTests.cs
+++ b/test/sent/SentServiceTests.cs
@@ -64,6 +64,39 @@ namespace com.esendex.sdk.test.sent
         }
 
         [Test]
+        public void GetBatchMessages_WithId_ReturnsSentBatchMessages()
+        {
+            // Arrange
+            var pageNumber = 1;
+            var pageSize = 15;
+            var id = Guid.NewGuid();
+
+            RestResource resource = new MessageBatchesResource(id);
+
+            var response = new RestResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = "serialisedItem"
+            };
+
+            var expectedResult = new SentMessageCollection();
+
+            mockRestClient
+                .Setup(rc => rc.Get(resource))
+                .Returns(response);
+
+            mockSerialiser
+                .Setup(s => s.Deserialise<SentMessageCollection>(response.Content))
+                .Returns(expectedResult);
+
+            // Act
+            var actualResult = service.GetBatchMessages(id);
+
+            // Assert
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [Test]
         public void GetMessage_WithId_ReturnsSentMessage()
         {
             // Arrange


### PR DESCRIPTION
Hi there!

I've recently had to implement a page that lists all SMS messages together with their status. I've looked around the .NET SDK and have not been able to find any functionality to retrieve messages through the Batch ID. 

Just wondering if such functionality will be included soon? 
Anyway, I played around with the .NET SDK and added that one functionality. Would this be a good addition to the SDK?

Thanks!